### PR TITLE
'/users' endpoint

### DIFF
--- a/services/auth/README.MD
+++ b/services/auth/README.MD
@@ -32,7 +32,7 @@ As of right now these endpoints have been implemented with the following functio
   - POST: Creates a new user
   - example: with curl 
   ```bash 
-  curl --url "http://auth.$PROJECT_DOMAIN/api/v1/auth/users" \
+  curl --url "http://$PROJECT_DOMAIN/api/v1/auth/users" \
        --header 'content-type: application/json' \
        --data '{
           "username": "user1",
@@ -44,10 +44,18 @@ As of right now these endpoints have been implemented with the following functio
   - POST: Logs in a user and returns a JWT
   - example: with curl 
   ```bash
-  curl --url "http://auth.$PROJECT_DOMAIN/api/v1/auth/users/login" \
+  curl --url "http://$PROJECT_DOMAIN/api/v1/auth/users/login" \
        --header 'content-type: application/json' \
        --data '{
           "username": "user1",
           "password": "user1"
         }'
+  ```
+
+- '/api/v1/auth/users'
+  - GET: Returns a list of all users
+  - example: with curl 
+  ```bash
+  curl --request GET "http://$PROJECT_DOMAIN/api/v1/auth/users" \
+  --header "authorization: Bearer <$JWT_TOKEN>"
   ```

--- a/services/auth/src/db/user.rs
+++ b/services/auth/src/db/user.rs
@@ -16,9 +16,10 @@ use uuid::Uuid;
 use crate::{
     config::secret::SecretService,
     error::AppError,
-    models::user::{NewUser, User},
+    models::user::{NewUser, SimpleUser, User},
 };
 
+#[derive(Debug)]
 pub struct UserRepo {
     pool: Arc<PgPool>,
 }
@@ -103,6 +104,16 @@ impl UserRepo {
             .await?;
 
         Ok(possible_user)
+    }
+
+    pub async fn get_all_users(&self) -> Result<Option<Vec<SimpleUser>>> {
+        //! get all the users from the database and return them as a vector
+
+        let users = query_as::<_, SimpleUser>("select * from users")
+            .fetch_all(&*self.pool)
+            .await?;
+
+        Ok(Some(users))
     }
 }
 

--- a/services/auth/src/handlers/auth.rs
+++ b/services/auth/src/handlers/auth.rs
@@ -5,7 +5,7 @@ use actix_web::{
 };
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, instrument};
 use uuid::Uuid;
 
 use crate::{
@@ -65,6 +65,7 @@ impl FromRequest for AuthenticatedUser {
     }
 }
 
+#[instrument(skip(loginfo, repo, secret_service))]
 pub async fn auth(
     loginfo: Json<Loginfo>,
     repo: UserRepo,

--- a/services/auth/src/handlers/mod.rs
+++ b/services/auth/src/handlers/mod.rs
@@ -8,7 +8,10 @@ use actix_web::{
 
 use crate::error::AppError;
 
-use self::{auth::auth, user::create_user};
+use self::{
+    auth::auth,
+    user::{create_user, list_users},
+};
 
 // QOL shorthands
 type AppResult<T> = Result<T, AppError>;
@@ -18,9 +21,11 @@ pub fn app_config(config: &mut ServiceConfig) {
     //! This function is where all the middleware and the routes are registered.
     //! as of right now this is rather bare as this the API, we didn't really specify what this service is responsible for.
 
-    let signup = web::resource("/users").route(web::post().to(create_user));
+    let users = web::resource("/users")
+        .route(web::post().to(create_user))
+        .route(web::get().to(list_users));
 
     let auth = web::resource("/users/login").route(web::post().to(auth));
 
-    config.service(signup).service(auth);
+    config.service(users).service(auth);
 }

--- a/services/auth/src/handlers/user.rs
+++ b/services/auth/src/handlers/user.rs
@@ -72,11 +72,12 @@ pub async fn list_self(user: AuthenticatedUser, user_repo: UserRepo) -> AppRespo
     Ok(HttpResponse::Ok().json(user))
 }
 
-pub async fn list_users(user_repo: UserRepo) -> AppResponse {
+#[instrument[skip(user_repo)]]
+pub async fn list_users(user_repo: UserRepo, user: AuthenticatedUser) -> AppResponse {
     let user = user_repo
-        .get_all_users()
+        .get_all_users(user.0)
         .await?
-        .ok_or(AppError::INTERNAL_ERROR)?;
+        .ok_or(AppError::NOT_AUTHORIZED)?;
 
     Ok(HttpResponse::Ok().json(user))
 }

--- a/services/auth/src/handlers/user.rs
+++ b/services/auth/src/handlers/user.rs
@@ -1,17 +1,17 @@
 use actix_web::{
     web::{Data, Json},
-    HttpResponse,
+    HttpRequest, HttpResponse,
 };
 
 use regex::Regex;
 
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::{
     config::secret::SecretService, db::user::UserRepo, error::AppError, models::user::NewUser,
 };
 
-use super::AppResponse;
+use super::{auth::AuthenticatedUser, AppResponse};
 
 pub async fn create_user(
     user: Json<NewUser>,
@@ -60,4 +60,23 @@ pub async fn create_user(
             }
         }
     }
+}
+
+#[instrument[skip(user_repo)]]
+pub async fn list_self(user: AuthenticatedUser, user_repo: UserRepo) -> AppResponse {
+    let user = user_repo
+        .find_by_id(user.0)
+        .await?
+        .ok_or(AppError::INTERNAL_ERROR)?;
+
+    Ok(HttpResponse::Ok().json(user))
+}
+
+pub async fn list_users(user_repo: UserRepo) -> AppResponse {
+    let user = user_repo
+        .get_all_users()
+        .await?
+        .ok_or(AppError::INTERNAL_ERROR)?;
+
+    Ok(HttpResponse::Ok().json(user))
 }

--- a/services/auth/src/models/user.rs
+++ b/services/auth/src/models/user.rs
@@ -22,3 +22,11 @@ pub struct NewUser {
     pub password: String,
     pub email: String,
 }
+
+#[derive(Serialize, sqlx::FromRow, Debug, Deserialize)]
+/// Struct which represents information about a user that is safe to send to the client
+pub struct SimpleUser {
+    pub username: String,
+    pub role: String,
+    pub email: String,
+}


### PR DESCRIPTION
Create `/users` endpoint, which will list all users if given a valid JWT with a user that is marked as admin.
Refer to README for how to test it.

As of right now,  no endpoint is currently made that will create an admin user.

I used `kubectl exec -it -n project auth-postgres-postgresql-0 -- /bin/bash` to access containers `psql` to change a user to admin. A migration will be needed to add an admin user. 